### PR TITLE
Add the s3:PutObjectAcl permission to the policy generated for deploy…

### DIFF
--- a/AWS/cloudformation-templates/s3-and-cloudfront.json
+++ b/AWS/cloudformation-templates/s3-and-cloudfront.json
@@ -221,7 +221,7 @@
           "PolicyDocument": {
             "Version": "2012-10-17",
             "Statement": [{
-              "Action": ["s3:DeleteObject", "s3:GetObject", "s3:PutObject"],
+              "Action": ["s3:DeleteObject", "s3:GetObject", "s3:PutObject", "s3:PutObjectAcl"],
               "Effect": "Allow",
               "Resource": { "Fn::Join": ["", ["arn:aws:s3:::", { "Ref": "S3Bucket" }, "/*" ]]}
             }, {


### PR DESCRIPTION
… credentials in the s3-and-cloudfront cloudformation script

This patch adds the s3:PutObjectAcl to the policy generated for deploy credentials in the s3 and cloudfront cloudformation script. This is so that travis can add the public-read ACL when deploying a build to s3.

@jbuck R?